### PR TITLE
Set textarea value so the rendered raw block can be navigated

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/raw",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "keywords": [
     "codex editor",
     "raw",

--- a/src/index.js
+++ b/src/index.js
@@ -110,7 +110,7 @@ export default class RawTool {
     wrapper.classList.add(this.CSS.baseClass, this.CSS.wrapper);
 
     this.textarea.classList.add(this.CSS.textarea, this.CSS.input);
-    this.textarea.textContent = this.data.html;
+    this.textarea.value = this.data.html;
     this.textarea.placeholder = this.placeholder;
 
     if (this.readOnly) {


### PR DESCRIPTION
By setting the textContent, user can't really navigate the textarea properly. The backspace and left arrow button are not working properly - they throw user to the block above.

Simirarly, when the user uses right/left arrow keys to navigate INTO the raw block, nothing happens.

I made a small reproducible example here https://stackblitz.com/edit/vitejs-vite-yueesx?file=index.html